### PR TITLE
Fixed most errors in the plugin

### DIFF
--- a/data/+omnis.txt
+++ b/data/+omnis.txt
@@ -117,16 +117,6 @@ system "Altera"
 		distance 1200
 		offset 320
 #
-	object "Decurion"
-		sprite "ship/decurion"
-		distance 1500
-		offset 40
-#
-	object "Centurion"
-		sprite "ship/centurion"
-		distance 1650
-		offset 80
-#
 	object "Spectre"
 		sprite "ship/spectre"
 		distance 1500
@@ -210,20 +200,6 @@ planet "Azrael"
 		threshold 0
 		fleet "azrael"
 
-planet "Centurion"
-	bribe 0
-	government "arena"
-	tribute 1
-		threshold 0
-		fleet "centurion"
-
-planet "Decurion"
-	bribe 0
-	government "arena"
-	tribute 1
-		threshold 0
-		fleet "decurion"
-
 planet "Paragon"
 	bribe 0
 	government "arena"
@@ -244,6 +220,9 @@ planet "Spectre"
 	tribute 1
 		threshold 0
 		fleet "spectre"
+
+planet "altera gateway"
+	description ``
 
 # ----------
 #   FLEETS
@@ -276,20 +255,6 @@ fleet "azrael"
 		heroic
 	variant
 		"Azrael"
-
-fleet "centurion"
-	government "arena"
-	personality
-		heroic
-	variant
-		"Centurion"
-
-fleet "decurion"
-	government "arena"
-	personality
-		heroic
-	variant
-		"Decurion"
 
 fleet "paragon"
 	government "arena"

--- a/data/alteran fleets.txt
+++ b/data/alteran fleets.txt
@@ -75,7 +75,6 @@ fleet "Altera Freight"
 		forbearing
 	variant
 		"Aetheris (Interceptor)" 4
-		"Centurion" 3
 		"Praesidium" 2
 
 fleet "Altera Merchant"
@@ -83,3 +82,5 @@ fleet "Altera Merchant"
 	names "civilian"
 	personality
 		timid
+	variant
+		"Carrum"

--- a/data/alteran ships.txt
+++ b/data/alteran ships.txt
@@ -30,7 +30,7 @@ ship "Aegis"
 		"Ancient Drone" 40
 
 		"ADRX-II Draconic Reactor"
-		"AAUX-I	Accumulation Unit"
+		"AAUX-I Accumulation Unit"
 		"AAUX-II Accumulation Unit"
 		"ASSX-II Shield System"
 		"AACX-II Cooling System"
@@ -313,7 +313,7 @@ ship "Arqueus"
 		"Ancient Anti-Missile"
 
 		"ADRX-I Draconic Reactor"
-		"AAUX-I	Accumulation Unit" 2
+		"AAUX-I Accumulation Unit" 2
 		"ASSX-I Shield System"
 		"AACX-I Cooling System"
 		
@@ -585,10 +585,10 @@ ship "Aurora"
 		under
 		right
 
-	gun -35.5 -281.5 "ASGX Solar Collector"
-	gun -35.5 -281.5 "ASGX Solar Collector"
-	gun 35.5 -281.5 "ASGX Solar Collector"
-	gun 35.5 -281.5 "ASGX Solar Collector"
+	gun -35.5 -281.5 #"ASGX Solar Collector"
+	gun -35.5 -281.5 #"ASGX Solar Collector"
+	gun 35.5 -281.5 #"ASGX Solar Collector"
+	gun 35.5 -281.5 #"ASGX Solar Collector"
 	gun -46.5 -162.5 "Ancient Drone Bay"
 	gun -46.5 -162.5 "Ancient Drone Bay"
 	gun 46.5 -162.5 "Ancient Drone Bay"
@@ -738,7 +738,7 @@ ship "Auxilus"
 		under
 		right
 
-	turret -0.5 -216.5 "Ancient Shock Turret""
+	turret -0.5 -216.5 "Ancient Shock Turret"
 	turret -0.5 -161.5 "Ancient Shock Turret"
 	turret -0.5 61 "Ancient Anti-Missile"
 	gun -29 -263.5 "Ancient Drone Bay"
@@ -1180,7 +1180,7 @@ ship "Gladius"
 	explode "tiny explosion" 15
 	explode "small explosion" 5
 	description ""
-	
+
 ship "Modified Tutela"
 	sprite "ship/mtutela"
 	thumbnail "thumbnail/mtutela"
@@ -1608,9 +1608,7 @@ ship "Praesidium"
 		"ASSX-II Shield System"
 		"AACX-I Cooling System"
 		
-		"AAGTX-I Anti-Grav Steering" 0
 		"AAGTX-II Anti-Grav Steering"
-		"AAGTX-I Anti-Grav Thruster" 0
 		"AAGTX-II Anti-Grav Thruster"
 		"AJX Star Drive"
 

--- a/data/depracated outfits.txt
+++ b/data/depracated outfits.txt
@@ -12,7 +12,7 @@ outfit "AAGTX-1.0 Anti-Grav Thruster"
 	"reverse thrust" 30
 	"reverse thrusting energy" 4.2
 	"reverse thrusting heat" 2
-	"flare sprite" "effect/Anti-Grav/Tier 1 Flare"
+	#"flare sprite" "effect/Anti-Grav/Tier 1 Flare"
 	"flare sound" "Anti-Grav T1"
 	description "Of all the Alteran Thrusters, this is the smallest and weakest. If compared to those of other races, it is very efficient and still powerful."
 	description "The Alteran Anti-Gravitational Thrusters require Ancient Technology to function, Alteran Shield Systems to be exact. The Anti-Grav Thrusters are infused with Draconium, which the moves the ship with the help of the Shield System's Anti-Gravitational Field."
@@ -30,7 +30,7 @@ outfit "AAGTX-2.0 Anti-Grav Thruster"
 	"reverse thrust" 70
 	"reverse thrusting energy" 8.0
 	"reverse thrusting heat" 4
-	"flare sprite" "effect/Anti-Grav/Tier 2 Flare"
+	#"flare sprite" "effect/Anti-Grav/Tier 2 Flare"
 	"flare sound" "Anti-Grav T2"
 	description "A larger variant of the Alteran Thrusting module, more efficient and more powerful than the smallest one. It can be compared to an upper half Plasma Thruster, in terms of pure strength."
 	description "The Alteran Anti-Gravitational Thrusters require Ancient Technology to function, Alteran Shield Systems to be exact. The Anti-Grav Thrusters are infused with Draconium, which the moves the ship with the help of the Shield System's Anti-Gravitational Field."
@@ -48,7 +48,7 @@ outfit "AAGTX-3.0 Anti-Grav Thruster"
 	"reverse thrust" 145.2
 	"reverse thrusting energy" 15.2
 	"reverse thrusting heat" 8.8
-	"flare sprite" "effect/Anti-Grav/Tier 3 Flare"
+	#"flare sprite" "effect/Anti-Grav/Tier 3 Flare"
 	"flare sound" "Anti-Grav T3"
 	description "The second-largest of the Alteran Thrusters is more powerful than all of the Human Thrusters, including the Atomic Thrusters. It is highly efficient, more efficient than even the Quarg Graviton Thrusters."
 	description "The Alteran Anti-Gravitational Thrusters require Ancient Technology to function, Alteran Shield Systems to be exact. The Anti-Grav Thrusters are infused with Draconium, which the moves the ship with the help of the Shield System's Anti-Gravitational Field."
@@ -66,8 +66,8 @@ outfit "AAGTX-4.0 Anti-Grav Thruster"
 	"reverse thrust" 319.4
 	"reverse thrusting energy" 28.8
 	"reverse thrusting heat" 19.4
-	"flare sprite" "effect/Anti-Grav/Tier 4 Flare"
-		"frame rate" 10
+	#"flare sprite" "effect/Anti-Grav/Tier 4 Flare"
+		#"frame rate" 10
 	"flare sound" "Anti-Grav T4"
 	description "The very expensive and truly gargantuan AAGTX-4.0 is nearly unrivalled in both power and efficiency. It's the peak of Alteran thrusting technology."
 	description "The Alteran Anti-Gravitational Thrusters require Ancient Technology to function, Alteran Shield Systems to be exact. The Anti-Grav Thrusters are infused with Draconium, which the moves the ship with the help of the Shield System's Anti-Gravitational Field."

--- a/data/effects.txt
+++ b/data/effects.txt
@@ -15,7 +15,7 @@ effect "Drone Impact"
 	"velocity scale" -.0001
 	
 effect "Ancient-Pulse Impact"
-	sprite "effect/Pulse/Ancient-Pulse Explosion"
+	sprite "effect/Pulse/Ancient-Pulse explosion"
 		"no repeat"
 		"frame rate" 5
 	"lifetime" 3

--- a/data/sales.txt
+++ b/data/sales.txt
@@ -21,7 +21,7 @@ outfitter "Ancient Basic"
 	"ASSX-I Shield System"
 	"ASSX-II Shield System"
 	
-	"AACX-1 Cooling System"
+	"AACX-I Cooling System"
 
 	"AJX Star Drive"
 
@@ -78,7 +78,7 @@ shipyard "Ancient Basic"
 	"Carrum"
 	"Castrum"
 	"Gladius"
-	"Modified Tetula"
+	"Modified Tutela"
 	"Praesidium"
 	"Tutela"
 	

--- a/data/ships_old.txt
+++ b/data/ships_old.txt
@@ -55,7 +55,7 @@ ship "Caesar"
 		"fuel capacity" 800
 		"cargo space" 750
 		"outfit space" 540
-		"weapon capacity" 170
+		"weapon capacity" 180
 		"engine capacity" 230
 		weapon
 			"blast radius" 190

--- a/data/special.txt
+++ b/data/special.txt
@@ -157,7 +157,7 @@ ship "Aurora (Spinal)"
 		"fuel capacity" 700
 		"cargo space" 180
 		"outfit space" 2010
-		"weapon capacity" 980
+		"weapon capacity" 1140
 		"engine capacity" 270
 		"ZPM capacity" 2
 		weapon
@@ -278,10 +278,10 @@ ship "Aurora (Spinal)"
 		angle -90
 		under
 		right
-	gun -35.5 -281.5 "ASGX Solar Collector"
-	gun -35.5 -281.5 "ASGX Solar Collector"
-	gun 35.5 -281.5 "ASGX Solar Collector"
-	gun 35.5 -281.5 "ASGX Solar Collector"
+	gun -35.5 -281.5 #"ASGX Solar Collector"
+	gun -35.5 -281.5 #"ASGX Solar Collector"
+	gun 35.5 -281.5 #"ASGX Solar Collector"
+	gun 35.5 -281.5 #"ASGX Solar Collector"
 	gun -46.5 -162.5 "Ancient Drone Bay"
 	gun -46.5 -162.5 "Ancient Drone Bay"
 	gun 46.5 -162.5 "Ancient Drone Bay"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -68,20 +68,20 @@ ship "Aetheris" "Aetheris (Interceptor)"
 
 ship "Arqueus" "Arqueus (Armed)"
 	outfits
-		"Ancient Drone Launcher"
+		"Ancient Drone Launcher" 2
 		"Ancient Drone Storage"
 		"Ancient Drone" 148
 		"Ancient Pulse Turret"
 		"Ancient Anti-Missile"
 		"ADRX-I Draconic Reactor"
-		"AAUX-I Accumulation Unit" 2
+		"AAUX-I Accumulation Unit"
 		"ASSX-I Shield System"
 		"AACX-I Cooling System"
 		"AAGTX-II Anti-Grav Steering"
 		"AAGTX-II Anti-Grav Thruster"
 		"AJX Star Drive"
 	gun "Ancient Drone Launcher"
-	gun
+	gun "Ancient Drone Launcher"
 	gun
 	gun
 	turret "Ancient Anti-Missile"
@@ -180,14 +180,16 @@ ship "Gladius" "Gladius (Interceptor)"
 ship "Paragon" "Paragon (Shock)"
 	outfits
 		"Ancient Drone Launcher" 4
+		"Ancient Drone Storage"
 		"Ancient Pulse Turret" 3
 		"Ancient Shock Turret" 2
 		"Ancient Anti-Missile" 2
-		"Ancient Drone" 80
+		"Ancient Drone" 188
 		"ADRX-III Draconic Reactor"
 		"AAUX-II Accumulation Unit"
 		"ASSX-III Shield System"
 		"AACX-II Cooling System"
+		"Outfits Expansion"
 		"AAGTX-III Anti-Grav Steering"
 		"AAGTX-III Anti-Grav Thruster"
 		"AJX Star Drive"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -1,13 +1,13 @@
 
-ship "Aegis" "Aegis (Pulse)
+ship "Aegis" "Aegis (Pulse)"
 	outfits
 		"Ancient Drone Launcher" 2
-		"Ancient Singular Pulse" 10
+		"Ancient Singular Pulse" 8
 		"Ancient Pulse Turret"
 		"Ancient Anti-Missile"
 		"Ancient Drone" 4
 		"ADRX-II Draconic Reactor"
-		"AAUX-I	Accumulation Unit"
+		"AAUX-I Accumulation Unit"
 		"AAUX-II Accumulation Unit"
 		"ASSX-II Shield System"
 		"AACX-II Cooling System"
@@ -68,20 +68,20 @@ ship "Aetheris" "Aetheris (Interceptor)"
 
 ship "Arqueus" "Arqueus (Armed)"
 	outfits
-		"Ancient Drone Launcher" 2
+		"Ancient Drone Launcher"
 		"Ancient Drone Storage"
 		"Ancient Drone" 148
 		"Ancient Pulse Turret"
 		"Ancient Anti-Missile"
 		"ADRX-I Draconic Reactor"
-		"AAUX-I	Accumulation Unit" 2
+		"AAUX-I Accumulation Unit" 2
 		"ASSX-I Shield System"
 		"AACX-I Cooling System"
 		"AAGTX-II Anti-Grav Steering"
 		"AAGTX-II Anti-Grav Thruster"
 		"AJX Star Drive"
 	gun "Ancient Drone Launcher"
-	gun "Ancient Drone Launcher"
+	gun
 	gun
 	gun
 	turret "Ancient Anti-Missile"
@@ -148,8 +148,8 @@ ship "Gladius" "Gladius (Beam)"
 		"AACX-I Cooling System"
 		"AAGTX-I Anti-Grav Steering"
 		"AAGTX-I Anti-Grav Thruster"
-	gun "Ancient Singular Pulse"
-	gun "Ancient Singular Pulse"
+	gun "Ancient Plasma Beam"
+	gun "Ancient Plasma Beam"
 
 ship "Gladius" "Gladius (Drone)"
 	outfits
@@ -162,8 +162,8 @@ ship "Gladius" "Gladius (Drone)"
 		"AAGTX-I Anti-Grav Steering"
 		"AAGTX-I Anti-Grav Thruster"
 		"AJX Star Drive"
-	gun "Ancient Singular Pulse"
-	gun "Ancient Singular Pulse"
+	gun "Ancient Drone Launcher"
+	gun "Ancient Drone Launcher"
 
 ship "Gladius" "Gladius (Interceptor)"
 	outfits
@@ -180,11 +180,10 @@ ship "Gladius" "Gladius (Interceptor)"
 ship "Paragon" "Paragon (Shock)"
 	outfits
 		"Ancient Drone Launcher" 4
-		"Ancient Drone Storage"
 		"Ancient Pulse Turret" 3
 		"Ancient Shock Turret" 2
 		"Ancient Anti-Missile" 2
-		"Ancient Drone" 188
+		"Ancient Drone" 80
 		"ADRX-III Draconic Reactor"
 		"AAUX-II Accumulation Unit"
 		"ASSX-III Shield System"
@@ -204,7 +203,7 @@ ship "Paragon" "Paragon (Shock)"
 	turret "Ancient Shock Turret"
 	turret "Ancient Anti-Missile"
 
-ship "Plaustrum" "Plaustrum (Armed)
+ship "Plaustrum" "Plaustrum (Armed)"
 	outfits
 		"Ancient Pulse Turret" 2
 		"Ancient Anti-Missile"


### PR DESCRIPTION
Was on a roll with fixing errors for Shields Up, so took a crack at cleaning up Altera, as well. Quick runthrough of the changes:

- Removed references to the Decurion and Centurion, since they no longer seem to be in the files
- Added description to Omnis altera gateway planet to fully define it
- Added a ship to the Altera merchant fleet to finishing defining it
- Replaced sneaky tabs with spaces in outfit lists
- Commented out solar collectors in gun slots. They'll reduce the gun slots properly, but can't actually be assigned to them.
- Commented out deprecated flare sprites
- Caught one more Tetula/Tutela
- Equipped weapons assigned to the Gladius variants with their proper slots
- Capacity changes on the Spinal Aurora and Caesar so they could fit their loadouts
- Other adjustments to variants so they fit their loadouts
- Various other little typos/missing quotes

There are only three sets of errors left that I can tell:

- Undefined references to other governments if you don't have their plugins (naturally)
- Alteran hails are undefined
- No plugin sprite

Which are all pretty manageable. Feel free to use/modify/leave what you need from this PR, hopefully it's of use.
